### PR TITLE
Fix tests

### DIFF
--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -73,7 +73,7 @@ make_cancellation_message(const std::string& vj_uri, const std::string& date) {
     return trip_update;
 }
 
-pbnavitia::Response compute_iti(
+static pbnavitia::Response compute_iti(
     const ed::builder& b,
     const char* datetime, 
     const std::string& from, 

--- a/source/routing/benchmark_raptor_cache.cpp
+++ b/source/routing/benchmark_raptor_cache.cpp
@@ -56,7 +56,7 @@ struct Demand {
     nt::AccessibiliteParams accessibilite_params;
 };
 
-void compute(std::vector<Demand> demands, boost::progress_display& show_progress, const type::Data& data){
+static void compute(std::vector<Demand> demands, boost::progress_display& show_progress, const type::Data& data){
 
     std::random_shuffle(demands.begin(), demands.end());
     std::vector<const CachedNextStopTime*> results;

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -271,6 +271,9 @@ inline bool operator<(StopTimeUpdate::Status a, StopTimeUpdate::Status b) {
 namespace detail {
 struct AuxInfoForMetaVJ {
     std::vector<StopTimeUpdate> stop_times;
+    // get the corresponding StopTime in the VJ associated to given StopTimeUpdate
+    // returns null if nothing found
+    const StopTime* get_vj_stop_time(const StopTimeUpdate&) const;
 
     template<class Archive>
     void serialize(Archive& ar, const unsigned int) {

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -133,9 +133,12 @@ struct PbCreator::Filler::PtObjVisitor: public boost::static_visitor<> {
                                                            impacted_stop->mutable_amended_stop_time());
 
             // we need to get the base stoptime
-            const auto* base_st = stu.stop_time.get_base_stop_time();
-            if (base_st) {
-                filler.copy(0, DumpMessage::No).fill_pb_object(base_st, impacted_stop->mutable_base_stop_time());
+            const auto* vj_st = impact.aux_info.get_vj_stop_time(stu);
+            if (vj_st) {
+                const auto* base_st = vj_st->get_base_stop_time();
+                if (base_st) {
+                    filler.copy(0, DumpMessage::No).fill_pb_object(base_st, impacted_stop->mutable_base_stop_time());
+                }
             }
         }
     }

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -196,7 +196,7 @@ const StopTime* StopTime::get_base_stop_time() const {
     // We get the rank of the stop_stime in the current VJ, and 
     // return the one with same rank in the base VJ. 
     // There are limitations if:
-    //   * the lollopop's node (stop_point B) is added before 
+    //   * the lollipop's node (stop_point B) is added before
     //          ie. Base VJ:     A - B - C - B - D
     //              RT VJ:   B - A - B - C - B - D 
     //   * the first stop time of the node is deleted
@@ -223,7 +223,8 @@ const StopTime* StopTime::get_base_stop_time() const {
     }
 
     auto logger = log4cplus::Logger::getInstance("log");
-    LOG4CPLUS_DEBUG(logger, "Ignored stop_time " << stop_point->uri << ":" << departure_time << ": impossible to match exactly one base stop_time");
+    LOG4CPLUS_DEBUG(logger, "Ignored stop_time " << stop_point->uri << ":" << departure_time
+                            << ": impossible to match exactly one base stop_time");
     return nullptr;
 }
 


### PR DESCRIPTION
In the second commit, first search for stop_time in RT VJ, then get the one from base VJ.
It's necessary because we compare addresses and type StopTime as multiple owners (STU and VJ) :cry: 

Not sure this is the best approach, maybe we should implement a compare not based on address but on SP and times if it's doable.

Maybe we should also protect the use of STU.stop_point (do a separate inherited type ?).
Anyway, a closer check at other uses of this STU.stop_point should be done, in case we have the same problem of thinking we use something from VJ, while it's from STU.